### PR TITLE
Added secure option for gravatar SSL Urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ You can also specify the size of the image with the following
 
 A valid size is between 1 - 2048.
 
+You can also use https://secure.gravatar.com/ URL, by passing the 3rd parameter to true.
+
+###Example
+    newUser.avatar = gravatar.imageUrl('test@gmail.com', { "size": "200" }, true);

--- a/lib/gravatarimage.js
+++ b/lib/gravatarimage.js
@@ -2,8 +2,8 @@ var crypto = require('crypto');
 var querystring = require('querystring');
 
 var gravatar = module.exports = {
-    imageUrl: function(email, parameters) {
-        var baseUrl = 'http://www.gravatar.com/avatar/';
+    imageUrl: function(email, parameters, secure) {
+        var baseUrl = (secure)? 'https://secure.gravatar.com/avatar/' : 'http://www.gravatar.com/avatar/';
         var result = "";
         var convertedQueryString = querystring.stringify(parameters);
 


### PR DESCRIPTION
Currently, only http is supported, and in order to support https, added https gravatar URL if secure parameter is set to true.

More Information here: https://en.gravatar.com/site/implement/images/
